### PR TITLE
"oc build-logs" is now deprecated. So we need to replace this comment.

### DIFF
--- a/08-S2I-Introduction.md
+++ b/08-S2I-Introduction.md
@@ -165,7 +165,7 @@ You'll see something like:
 
 You can view the build logs from the command line with:
 
-    oc build-logs example-1
+    oc logs sinatra-example-1-build
 
 Why just `example-1`?
 


### PR DESCRIPTION
The _oc build-logs_ command is now deprecated. We now need to update this with a _oc log_. 